### PR TITLE
removed redundant/unused parameters 'value'

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function setPrivateKey(value) {
   private_key = value
 }
 
-function getPrivateKey(value) {
+function getPrivateKey() {
   return private_key
 }
 
@@ -15,7 +15,7 @@ function setPublicKey(value) {
   public_key = value
 }
 
-function getPublicKey(value) {
+function getPublicKey() {
   return public_key
 }
 


### PR DESCRIPTION
Removed the 'value' parameters for the `getPrivateKey()` and `getPublicKey()` functions as they were redundant/unused. Also resolved a typo that I previously brought up as part of an issue [here](https://github.com/restuhaqza/digital-signature/issues/6). 